### PR TITLE
Update to Minecraft 1.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.2.7-SNAPSHOT'
+    id 'fabric-loom' version '0.4-SNAPSHOT'
     id "com.matthewprenger.cursegradle" version "1.4.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.16-pre7
-yarn_mappings=1.16-pre7+build.1
-loader_version=0.8.7+build.201
+minecraft_version=1.16
+yarn_mappings=1.16+build.1
+loader_version=0.8.8+build.202
 
 # Mod Properties
 mod_version=0.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=20w19a
-yarn_mappings=20w19a+build.9
-loader_version=0.8.2+build.194
+minecraft_version=1.16-pre7
+yarn_mappings=1.16-pre7+build.1
+loader_version=0.8.7+build.201
 
 # Mod Properties
 mod_version=0.6.0

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorageData.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorageData.java
@@ -34,7 +34,7 @@ public abstract class MixinBlockLightStorageData extends ChunkToNibbleArrayMap<B
         // This will be called immediately by LightStorage in the constructor
         // We can take advantage of this fact to initialize our extra properties here without additional hacks
         if (!this.init) {
-            this.init();
+            this.initialize();
         }
 
         BlockLightStorage.Data data = new BlockLightStorage.Data(this.arrays);
@@ -44,7 +44,7 @@ public abstract class MixinBlockLightStorageData extends ChunkToNibbleArrayMap<B
         return data;
     }
 
-    private void init() {
+    private void initialize() {
         ((ChunkToNibbleArrayMapExtended) this).init();
 
         this.init = true;

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkSkyLightProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkSkyLightProvider.java
@@ -192,7 +192,7 @@ public abstract class MixinChunkSkyLightProvider extends ChunkLightProvider<SkyL
         // Skylight optimization: Try to find bottom-most non-empty chunk
         if (localY == 0) {
             while (!this.lightStorage.hasLight(ChunkSectionPos.offset(chunkId, 0, -chunkOffsetY - 1, 0))
-                    && this.lightStorage.isAboveMinimumHeight(chunkY - chunkOffsetY - 1)) {
+                    && this.lightStorage.isAboveMinHeight(chunkY - chunkOffsetY - 1)) {
                 ++chunkOffsetY;
             }
         }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
@@ -350,7 +350,7 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> impl
      * @author JellySquid
      */
     @Overwrite
-    public void method_29967(ChunkLightProvider<M, ?> chunkLightProvider, long pos) {
+    private void method_29967(ChunkLightProvider<M, ?> chunkLightProvider, long pos) {
         if (this.hasLight(pos)) {
             int x = ChunkSectionPos.getWorldCoord(ChunkSectionPos.getX(pos));
             int y = ChunkSectionPos.getWorldCoord(ChunkSectionPos.getY(pos));

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorageData.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorageData.java
@@ -56,7 +56,7 @@ public class MixinSkyLightStorageData extends ChunkToNibbleArrayMap<SkyLightStor
         // This will be called immediately by LightStorage in the constructor
         // We can take advantage of this fact to initialize our extra properties here without additional hacks
         if (!this.init) {
-            this.init();
+            this.initialize();
         }
 
         SkyLightStorage.Data data = new SkyLightStorage.Data(this.arrays, this.topArraySectionY, this.defaultTopArraySectionY);
@@ -66,7 +66,7 @@ public class MixinSkyLightStorageData extends ChunkToNibbleArrayMap<SkyLightStor
         return data;
     }
 
-    private void init() {
+    private void initialize() {
         ((ChunkToNibbleArrayMapExtended) this).init();
 
         this.topArraySectionYQueue = new DoubleBufferedLong2IntHashMap();

--- a/src/main/resources/phosphor.accesswidener
+++ b/src/main/resources/phosphor.accesswidener
@@ -4,4 +4,4 @@ accessible class net/minecraft/block/AbstractBlock$AbstractBlockState$ShapeCache
 
 accessible method net/minecraft/world/chunk/light/LightStorage hasLight (J)Z
 accessible method net/minecraft/world/chunk/light/SkyLightStorage method_15565 (J)Z
-accessible method net/minecraft/world/chunk/light/SkyLightStorage isAboveMinimumHeight (I)Z
+accessible method net/minecraft/world/chunk/light/SkyLightStorage isAboveMinHeight (I)Z


### PR DESCRIPTION
The included update to 1.16-pre7 follows a small change from Mojang - LightStorage.updateLightArrays will work through a different, newly added queue when skipEdgeLightPropagation is true (when it would previously do nothing).
The code which propagates this was split into another method.
I've also renamed the lightProvider variable to chunkLightProvider to keep up with mappings, for clarity.

I've duplicated your Overwrite reason for this new method, since to me it seems accurarate enough for both parts. Maybe that could use an update though.