### PR TITLE
Move lightmap setup to earlier stage

### DIFF
--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/BlockLightStorageAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/BlockLightStorageAccess.java
@@ -1,0 +1,5 @@
+package me.jellysquid.mods.phosphor.common.chunk.light;
+
+public interface BlockLightStorageAccess {
+    boolean isLightEnabled(long sectionPos);
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/ServerLightingProviderAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/ServerLightingProviderAccess.java
@@ -1,0 +1,9 @@
+package me.jellysquid.mods.phosphor.common.chunk.light;
+
+import java.util.concurrent.CompletableFuture;
+
+import net.minecraft.world.chunk.Chunk;
+
+public interface ServerLightingProviderAccess {
+    CompletableFuture<Chunk> setupLightmaps(Chunk chunk);
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/world/ThreadedAnvilChunkStorageAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/world/ThreadedAnvilChunkStorageAccess.java
@@ -1,0 +1,7 @@
+package me.jellysquid.mods.phosphor.common.world;
+
+import net.minecraft.util.math.ChunkPos;
+
+public interface ThreadedAnvilChunkStorageAccess {
+    void invokeReleaseLightTicket(ChunkPos pos);
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/MixinChunkStatus.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/MixinChunkStatus.java
@@ -1,0 +1,68 @@
+package me.jellysquid.mods.phosphor.mixin.chunk;
+
+import com.mojang.datafixers.util.Either;
+import me.jellysquid.mods.phosphor.common.chunk.light.ServerLightingProviderAccess;
+import net.minecraft.server.world.ChunkHolder;
+import net.minecraft.server.world.ServerLightingProvider;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(ChunkStatus.class)
+public class MixinChunkStatus {
+    @Shadow
+    private static ChunkStatus register(String id, ChunkStatus previous, int taskMargin, EnumSet<Heightmap.Type> heightMapTypes, ChunkStatus.ChunkType chunkType, ChunkStatus.GenerationTask task, ChunkStatus.LoadTask noGenTask) {
+        return null;
+    }
+
+    @Shadow
+    @Final
+    private static ChunkStatus.LoadTask STATUS_BUMP_NO_GEN_TASK;
+
+    @Redirect(
+        method = "<clinit>",
+        slice = @Slice(
+            from = @At(value = "CONSTANT", args = "stringValue=features")
+        ),
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/chunk/ChunkStatus;register(Ljava/lang/String;Lnet/minecraft/world/chunk/ChunkStatus;ILjava/util/EnumSet;Lnet/minecraft/world/chunk/ChunkStatus$ChunkType;Lnet/minecraft/world/chunk/ChunkStatus$GenerationTask;)Lnet/minecraft/world/chunk/ChunkStatus;",
+            ordinal = 0
+        )
+    )
+    private static ChunkStatus injectLightmapSetup(final String id, final ChunkStatus previous, final int taskMargin, final EnumSet<Heightmap.Type> heightMapTypes, final ChunkStatus.ChunkType chunkType, final ChunkStatus.GenerationTask task) {
+        return register(id, previous, taskMargin, heightMapTypes, chunkType,
+            (status, world, generator, structureManager, lightingProvider, function, surroundingChunks, chunk) ->
+                task.doWork(status, world, generator, structureManager, lightingProvider, function, surroundingChunks, chunk).thenCompose(
+                    either -> getPreLightFuture(lightingProvider, either)
+                ),
+            (status, world, structureManager, lightingProvider, function, chunk) ->
+                STATUS_BUMP_NO_GEN_TASK.doWork(status, world, structureManager, lightingProvider, function, chunk).thenCompose(
+                    either -> getPreLightFuture(lightingProvider, either)
+                )
+            );
+    }
+
+    @Unique
+    private static CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>> getPreLightFuture(final ServerLightingProvider lightingProvider, final Either<Chunk, ChunkHolder.Unloaded> either) {
+        return either.map(
+            chunk -> getPreLightFuture(lightingProvider, chunk),
+            unloaded -> CompletableFuture.completedFuture(Either.right(unloaded))
+        );
+    }
+
+    @Unique
+    private static CompletableFuture<Either<Chunk, ChunkHolder.Unloaded>> getPreLightFuture(final ServerLightingProvider lightingProvider, final Chunk chunk) {
+        return ((ServerLightingProviderAccess) lightingProvider).setupLightmaps(chunk).thenApply(Either::left);
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorage.java
@@ -1,0 +1,36 @@
+package me.jellysquid.mods.phosphor.mixin.chunk.light;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import me.jellysquid.mods.phosphor.common.chunk.light.BlockLightStorageAccess;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.LightType;
+import net.minecraft.world.chunk.ChunkProvider;
+import net.minecraft.world.chunk.light.BlockLightStorage;
+import net.minecraft.world.chunk.light.LightStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(BlockLightStorage.class)
+public abstract class MixinBlockLightStorage extends LightStorage<BlockLightStorage.Data> implements BlockLightStorageAccess {
+    private MixinBlockLightStorage(final LightType lightType, final ChunkProvider chunkProvider, final BlockLightStorage.Data lightData) {
+        super(lightType, chunkProvider, lightData);
+    }
+
+    @Unique
+    private final LongSet lightEnabled = new LongOpenHashSet();
+
+    @Override
+    protected void setLightEnabled(final long chunkPos, final boolean enable) {
+        if (enable) {
+            this.lightEnabled.add(chunkPos);
+        } else {
+            this.lightEnabled.remove(chunkPos);
+        }
+    }
+
+    @Override
+    public boolean isLightEnabled(final long sectionPos) {
+        return this.lightEnabled.contains(ChunkSectionPos.withZeroZ(sectionPos));
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkBlockLightProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkBlockLightProvider.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
 import me.jellysquid.mods.phosphor.common.chunk.level.LevelPropagatorExtended;
+import me.jellysquid.mods.phosphor.common.chunk.light.BlockLightStorageAccess;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightProviderBlockAccess;
 import me.jellysquid.mods.phosphor.common.util.LightUtil;
 import me.jellysquid.mods.phosphor.common.util.math.DirectionHelper;
@@ -64,7 +65,8 @@ public abstract class MixinChunkBlockLightProvider extends ChunkLightProvider<Bl
     public int getPropagatedLevel(long fromId, BlockState fromState, long toId, int currentLevel) {
         if (toId == Long.MAX_VALUE) {
             return 15;
-        } else if (fromId == Long.MAX_VALUE) {
+        } else if (fromId == Long.MAX_VALUE && ((BlockLightStorageAccess) this.lightStorage).isLightEnabled(ChunkSectionPos.fromGlobalPos(toId))) {
+            // Disable blocklight sources before initial lighting
             return currentLevel + 15 - this.getLightSourceLuminance(toId);
         } else if (currentLevel >= 15) {
             return currentLevel;

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinServerLightingProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinServerLightingProvider.java
@@ -1,20 +1,26 @@
 package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
-import java.util.function.IntSupplier;
-
+import me.jellysquid.mods.phosphor.common.chunk.light.ServerLightingProviderAccess;
+import me.jellysquid.mods.phosphor.common.world.ThreadedAnvilChunkStorageAccess;
+import net.minecraft.server.world.ServerLightingProvider;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkProvider;
+import net.minecraft.world.chunk.ChunkSection;
+import net.minecraft.world.chunk.light.LightingProvider;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
-import net.minecraft.server.world.ServerLightingProvider;
-import net.minecraft.util.Util;
-import net.minecraft.util.math.ChunkSectionPos;
-import net.minecraft.world.chunk.ChunkProvider;
-import net.minecraft.world.chunk.light.LightingProvider;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.IntSupplier;
 
 @Mixin(ServerLightingProvider.class)
-public abstract class MixinServerLightingProvider extends LightingProvider
-{
+public abstract class MixinServerLightingProvider extends LightingProvider implements ServerLightingProviderAccess {
     private MixinServerLightingProvider(final ChunkProvider chunkProvider, final boolean hasBlockLight, final boolean hasSkyLight) {
         super(chunkProvider, hasBlockLight, hasSkyLight);
     }
@@ -54,5 +60,70 @@ public abstract class MixinServerLightingProvider extends LightingProvider
                 () -> "updateSectionStatus " + pos + " " + false
             ));
         }
+    }
+
+    @Override
+    public CompletableFuture<Chunk> setupLightmaps(final Chunk chunk) {
+        final ChunkPos chunkPos = chunk.getPos();
+
+        // This evaluates the non-empty subchunks concurrently on the lighting thread...
+        this.enqueue(chunkPos.x, chunkPos.z, () -> 0, ServerLightingProvider.Stage.PRE_UPDATE, Util.debugRunnable(() -> {
+            final ChunkSection[] chunkSections = chunk.getSectionArray();
+
+            for (int i = 0; i < chunkSections.length; ++i) {
+                if (!ChunkSection.isEmpty(chunkSections[i])) {
+                    super.updateSectionStatus(ChunkSectionPos.from(chunkPos, i), false);
+                }
+            }
+
+            if (chunk.isLightOn()) {
+                super.setLightEnabled(chunkPos, true);
+            }
+        },
+            () -> "setupLightmaps " + chunkPos
+        ));
+
+        return CompletableFuture.supplyAsync(() -> {
+            super.setRetainData(chunkPos, false);
+            return chunk;
+        },
+            (runnable) -> this.enqueue(chunkPos.x, chunkPos.z, () -> 0, ServerLightingProvider.Stage.POST_UPDATE, runnable)
+        );
+    }
+
+    @Shadow
+    @Final
+    private ThreadedAnvilChunkStorage chunkStorage;
+
+    /**
+     * @author PhiPro
+     * @reason Move parts of the logic to {@link #setupLightmaps(Chunk)}
+     */
+    @Overwrite
+    public CompletableFuture<Chunk> light(Chunk chunk, boolean excludeBlocks) {
+        final ChunkPos chunkPos = chunk.getPos();
+
+        this.enqueue(chunkPos.x, chunkPos.z, ServerLightingProvider.Stage.PRE_UPDATE, Util.debugRunnable(() -> {
+            if (!chunk.isLightOn()) {
+                super.setLightEnabled(chunkPos, true);
+            }
+
+            if (!excludeBlocks) {
+                chunk.getLightSourcesStream().forEach((blockPos) -> {
+                    super.addLightSource(blockPos, chunk.getLuminance(blockPos));
+                });
+            }
+        },
+            () -> "lightChunk " + chunkPos + " " + excludeBlocks
+        ));
+
+        return CompletableFuture.supplyAsync(() -> {
+            chunk.setLightOn(true);
+            ((ThreadedAnvilChunkStorageAccess) this.chunkStorage).invokeReleaseLightTicket(chunkPos);
+
+            return chunk;
+        },
+            (runnable) -> this.enqueue(chunkPos.x, chunkPos.z, ServerLightingProvider.Stage.POST_UPDATE, runnable)
+        );
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/world/MixinChunkSerializer.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/world/MixinChunkSerializer.java
@@ -1,0 +1,57 @@
+package me.jellysquid.mods.phosphor.mixin.world;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.structure.StructureManager;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.ChunkSerializer;
+import net.minecraft.world.LightType;
+import net.minecraft.world.chunk.ChunkNibbleArray;
+import net.minecraft.world.chunk.ProtoChunk;
+import net.minecraft.world.chunk.light.LightingProvider;
+import net.minecraft.world.poi.PointOfInterestStorage;
+
+@Mixin(ChunkSerializer.class)
+public abstract class MixinChunkSerializer {
+    @Inject(
+        method = "deserialize(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/structure/StructureManager;Lnet/minecraft/world/poi/PointOfInterestStorage;Lnet/minecraft/util/math/ChunkPos;Lnet/minecraft/nbt/CompoundTag;)Lnet/minecraft/world/chunk/ProtoChunk;",
+        at = @At(
+            value = "INVOKE_ASSIGN",
+            target = "Lnet/minecraft/world/chunk/ChunkManager;getLightingProvider()Lnet/minecraft/world/chunk/light/LightingProvider;",
+            ordinal = 0
+        )
+    )
+    private static void loadLightmaps(final ServerWorld world, final StructureManager structureManager, final PointOfInterestStorage poiStorage, final ChunkPos pos, final CompoundTag tag, final CallbackInfoReturnable<ProtoChunk> ci) {
+        final CompoundTag levelTag = tag.getCompound("Level");
+
+        // Load lightmaps of pre_light chunks unless erasing cached data
+        if (levelTag.getBoolean("isLightOn") || !levelTag.contains("Heightmaps", 10)) {
+            return;
+        }
+
+        final ListTag sections = levelTag.getList("Sections", 10);
+        final LightingProvider lightingProvider = world.getChunkManager().getLightingProvider();
+        final boolean hasSkyLight = world.getDimension().hasSkyLight();
+
+        lightingProvider.setRetainData(pos, true);
+
+        for(int i = 0; i < sections.size(); ++i) {
+            final CompoundTag section = sections.getCompound(i);
+            final int y = section.getByte("Y");
+
+            if (section.contains("BlockLight", 7)) {
+                lightingProvider.queueData(LightType.BLOCK, ChunkSectionPos.from(pos, y), new ChunkNibbleArray(section.getByteArray("BlockLight")), true);
+            }
+
+            if (hasSkyLight && section.contains("SkyLight", 7)) {
+                lightingProvider.queueData(LightType.SKY, ChunkSectionPos.from(pos, y), new ChunkNibbleArray(section.getByteArray("SkyLight")), true);
+            }
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/world/MixinThreadedAnvilChunkStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/world/MixinThreadedAnvilChunkStorage.java
@@ -6,11 +6,13 @@ import java.util.function.IntFunction;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.mojang.datafixers.util.Either;
 
+import me.jellysquid.mods.phosphor.common.world.ThreadedAnvilChunkStorageAccess;
 import net.minecraft.server.world.ChunkHolder;
 import net.minecraft.server.world.ChunkHolder.Unloaded;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
@@ -19,10 +21,13 @@ import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
 
 @Mixin(ThreadedAnvilChunkStorage.class)
-public abstract class MixinThreadedAnvilChunkStorage
-{
+public abstract class MixinThreadedAnvilChunkStorage implements ThreadedAnvilChunkStorageAccess {
     @Shadow
     protected abstract CompletableFuture<Either<List<Chunk>, Unloaded>> createChunkRegionFuture(final ChunkPos centerChunk, final int margin, final IntFunction<ChunkStatus> distanceToStatus);
+
+    @Override
+    @Invoker("releaseLightTicket")
+    public abstract void invokeReleaseLightTicket(ChunkPos pos);
 
     @Redirect(
         method = "createBorderFuture(Lnet/minecraft/server/world/ChunkHolder;)Ljava/util/concurrent/CompletableFuture;",

--- a/src/main/resources/phosphor.accesswidener
+++ b/src/main/resources/phosphor.accesswidener
@@ -2,6 +2,9 @@ accessWidener v1 named
 
 accessible class net/minecraft/block/AbstractBlock$AbstractBlockState$ShapeCache
 
+accessible class net/minecraft/world/chunk/ChunkStatus$GenerationTask
+accessible class net/minecraft/world/chunk/ChunkStatus$LoadTask
+
 accessible class net/minecraft/server/world/ServerLightingProvider$Stage
 
 accessible method net/minecraft/world/chunk/light/LightStorage hasLight (J)Z

--- a/src/main/resources/phosphor.mixins.json
+++ b/src/main/resources/phosphor.mixins.json
@@ -14,6 +14,7 @@
         "chunk.light.MixinChunkToNibbleArrayMap",
         "chunk.light.MixinLevelPropagator",
         "chunk.light.MixinLightStorage",
+        "chunk.light.MixinBlockLightStorage",
         "chunk.light.MixinSkyLightStorage",
         "chunk.light.MixinSkyLightStorageData",
         "chunk.light.MixinServerLightingProvider",

--- a/src/main/resources/phosphor.mixins.json
+++ b/src/main/resources/phosphor.mixins.json
@@ -19,7 +19,8 @@
         "chunk.light.MixinServerLightingProvider",
         "chunk.MixinProtoChunk",
         "world.MixinWorld",
-        "world.MixinThreadedAnvilChunkStorage"
+        "world.MixinThreadedAnvilChunkStorage",
+        "chunk.MixinChunkStatus"
     ],
     "injectors": {
         "defaultRequire": 1

--- a/src/main/resources/phosphor.mixins.json
+++ b/src/main/resources/phosphor.mixins.json
@@ -21,7 +21,8 @@
         "chunk.MixinProtoChunk",
         "world.MixinWorld",
         "world.MixinThreadedAnvilChunkStorage",
-        "chunk.MixinChunkStatus"
+        "chunk.MixinChunkStatus",
+        "world.MixinChunkSerializer"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
This fixes [MC-170012](https://bugs.mojang.com/browse/MC-170012).
The main point is to move the tracking of non-empty sections to an earlier generation stage, as otherwise initial lighting propagates into chunks that do not have their data setup yet properly. The code is based on https://github.com/PhiPro95/mc-fixes/tree/mc-170012, but attaches the additional tasks to the `features` stage instead of creating a new `pre_light` stage.

This PR moreover fixes the two related issue mentioned in the comments of the linked report arising from the missing distinction between `pre_ligth` and `light` stage:
* It disables source blocklight before the initial lighting, as otherwise light can sporadically propagate into chunks that are not even in the `features` stage.
* It loads lightmaps for chunks before the `light` stage, which are otherwise stripped by Vanilla.