### PR TITLE
Fix lightmap initialization and improve lightmap handling

### DIFF
--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/IReadonly.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/IReadonly.java
@@ -1,0 +1,5 @@
+package me.jellysquid.mods.phosphor.common.chunk.light;
+
+public interface IReadonly {
+    boolean isReadonly();
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/InitialLightingAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/InitialLightingAccess.java
@@ -1,7 +1,7 @@
 package me.jellysquid.mods.phosphor.common.chunk.light;
 
 public interface InitialLightingAccess {
-    void prepareInitialLighting(long chunkPos);
+    void enableSourceLight(long chunkPos);
 
-    void cancelInitialLighting(long chunkPos);
+    void enableLightUpdates(long chunkPos);
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/InitialLightingAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/InitialLightingAccess.java
@@ -1,0 +1,7 @@
+package me.jellysquid.mods.phosphor.common.chunk.light;
+
+public interface InitialLightingAccess {
+    void prepareInitialLighting(long chunkPos);
+
+    void cancelInitialLighting(long chunkPos);
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/LevelPropagatorAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/LevelPropagatorAccess.java
@@ -1,0 +1,5 @@
+package me.jellysquid.mods.phosphor.common.chunk.light;
+
+public interface LevelPropagatorAccess {
+    void invokePropagateLevel(long sourceId, long targetId, int level, boolean decrease);
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/LightStorageAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/LightStorageAccess.java
@@ -10,4 +10,12 @@ public interface LightStorageAccess {
      * This is analogous to {@link net.minecraft.world.chunk.light.LightStorage#getLight(long)}, but uses the cached light data.
      */
     int getLightWithoutLightmap(long blockPos);
+
+    /**
+     * Enables or disables light updates for the provided <code>chunkPos</code>.
+     * Disabling light updates additionally disables source light and removes all data associated to the chunk.
+     */
+    void setLightUpdatesEnabled(long chunkPos, boolean enabled);
+
+    void invokeSetColumnEnabled(long chunkPos, boolean enabled);
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/SkyLightStorageDataAccess.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/chunk/light/SkyLightStorageDataAccess.java
@@ -12,4 +12,6 @@ public interface SkyLightStorageDataAccess {
      * Returns the height map value for the given block column in the world.
      */
     int getHeight(long pos);
+
+    void updateMinHeight(int y);
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/EmptyChunkNibbleArray.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/EmptyChunkNibbleArray.java
@@ -1,0 +1,11 @@
+package me.jellysquid.mods.phosphor.common.util.chunk.light;
+
+public class EmptyChunkNibbleArray extends ReadonlyChunkNibbleArray {
+    public EmptyChunkNibbleArray() {
+    }
+
+    @Override
+    public byte[] asByteArray() {
+        return new byte[2048];
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/ReadonlyChunkNibbleArray.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/ReadonlyChunkNibbleArray.java
@@ -1,0 +1,23 @@
+package me.jellysquid.mods.phosphor.common.util.chunk.light;
+
+import me.jellysquid.mods.phosphor.common.chunk.light.IReadonly;
+import net.minecraft.world.chunk.ChunkNibbleArray;
+
+public class ReadonlyChunkNibbleArray extends ChunkNibbleArray implements IReadonly {
+    public ReadonlyChunkNibbleArray() {
+    }
+
+    public ReadonlyChunkNibbleArray(byte[] bs) {
+        super(bs);
+    }
+
+    @Override
+    public ChunkNibbleArray copy() {
+        return new ChunkNibbleArray(this.asByteArray());
+    }
+
+    @Override
+    public boolean isReadonly() {
+        return true;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/SkyLightChunkNibbleArray.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/common/util/chunk/light/SkyLightChunkNibbleArray.java
@@ -1,0 +1,25 @@
+package me.jellysquid.mods.phosphor.common.util.chunk.light;
+
+import net.minecraft.world.chunk.ChunkNibbleArray;
+
+public class SkyLightChunkNibbleArray extends ReadonlyChunkNibbleArray {
+    public SkyLightChunkNibbleArray(final ChunkNibbleArray inheritedLightmap) {
+        super(inheritedLightmap.asByteArray());
+    }
+
+    @Override
+    protected int getIndex(final int x, final int y, final int z) {
+        return super.getIndex(x, 0, z);
+    }
+
+    @Override
+    public byte[] asByteArray() {
+        byte[] byteArray = new byte[2048];
+
+        for(int i = 0; i < 16; ++i) {
+            System.arraycopy(this.byteArray, 0, byteArray, i * 128, 128);
+        }
+
+        return byteArray;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/MixinChunkNibbleArray.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/MixinChunkNibbleArray.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.phosphor.mixin.chunk;
 
+import me.jellysquid.mods.phosphor.common.chunk.light.IReadonly;
 import net.minecraft.world.chunk.ChunkNibbleArray;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -10,7 +11,7 @@ import org.spongepowered.asm.mixin.Shadow;
  * the right bit index of a nibble.
  */
 @Mixin(ChunkNibbleArray.class)
-public abstract class MixinChunkNibbleArray {
+public abstract class MixinChunkNibbleArray implements IReadonly {
     @Shadow
     protected byte[] byteArray;
 
@@ -38,6 +39,10 @@ public abstract class MixinChunkNibbleArray {
      */
     @Overwrite
     private void set(int idx, int value) {
+        if (this.isReadonly()) {
+            throw new UnsupportedOperationException("Cannot modify readonly ChunkNibbleArray");
+        }
+
         byte[] arr = this.byteArray;
 
         if (arr == null) {
@@ -49,5 +54,10 @@ public abstract class MixinChunkNibbleArray {
 
         arr[byteIdx] = (byte) ((arr[byteIdx] & ~(15 << shift))
                 | ((value & 15) << shift));
+    }
+
+    @Override
+    public boolean isReadonly() {
+        return false;
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinBlockLightStorage.java
@@ -4,19 +4,13 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import me.jellysquid.mods.phosphor.common.chunk.light.BlockLightStorageAccess;
 import net.minecraft.util.math.ChunkSectionPos;
-import net.minecraft.world.LightType;
-import net.minecraft.world.chunk.ChunkProvider;
+import net.minecraft.world.chunk.ChunkNibbleArray;
 import net.minecraft.world.chunk.light.BlockLightStorage;
-import net.minecraft.world.chunk.light.LightStorage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(BlockLightStorage.class)
-public abstract class MixinBlockLightStorage extends LightStorage<BlockLightStorage.Data> implements BlockLightStorageAccess {
-    private MixinBlockLightStorage(final LightType lightType, final ChunkProvider chunkProvider, final BlockLightStorage.Data lightData) {
-        super(lightType, chunkProvider, lightData);
-    }
-
+public abstract class MixinBlockLightStorage extends MixinLightStorage<BlockLightStorage.Data> implements BlockLightStorageAccess {
     @Unique
     private final LongSet lightEnabled = new LongOpenHashSet();
 
@@ -32,5 +26,25 @@ public abstract class MixinBlockLightStorage extends LightStorage<BlockLightStor
     @Override
     public boolean isLightEnabled(final long sectionPos) {
         return this.lightEnabled.contains(ChunkSectionPos.withZeroY(sectionPos));
+    }
+
+    @Override
+    protected int getLightmapComplexityChange(final long blockPos, final int oldVal, final int newVal, final ChunkNibbleArray lightmap) {
+        return newVal - oldVal;
+    }
+
+    @Override
+    protected int getInitialLightmapComplexity(final long sectionPos, final ChunkNibbleArray lightmap) {
+        int complexity = 0;
+
+        for (int y = 0; y < 16; ++y) {
+            for (int z = 0; z < 16; ++z) {
+                for (int x = 0; x < 16; ++x) {
+                    complexity += lightmap.get(x, y, z);
+                }
+            }
+        }
+
+        return complexity;
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkLightProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinChunkLightProvider.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import me.jellysquid.mods.phosphor.common.block.BlockStateLightInfo;
 import me.jellysquid.mods.phosphor.common.block.BlockStateLightInfoAccess;
 import me.jellysquid.mods.phosphor.common.chunk.level.LevelUpdateListener;
+import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightInitializer;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightProviderBlockAccess;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightProviderUpdateTracker;
@@ -34,7 +35,7 @@ import java.util.BitSet;
 
 @Mixin(ChunkLightProvider.class)
 public abstract class MixinChunkLightProvider<M extends ChunkToNibbleArrayMap<M>, S extends LightStorage<M>>
-        extends LevelPropagator implements LightProviderUpdateTracker, LightProviderBlockAccess, LightInitializer, LevelUpdateListener {
+        extends LevelPropagator implements LightProviderUpdateTracker, LightProviderBlockAccess, LightInitializer, LevelUpdateListener, InitialLightingAccess {
     private static final BlockState DEFAULT_STATE = Blocks.AIR.getDefaultState();
 
     @Shadow
@@ -279,5 +280,19 @@ public abstract class MixinChunkLightProvider<M extends ChunkToNibbleArrayMap<M>
         int z = BlockPos.unpackLongZ(blockPos) & 15;
 
         return (x << 8) | (y << 4) | z;
+    }
+
+    @Shadow
+    @Final
+    protected LightStorage<?> lightStorage;
+
+    @Override
+    public void prepareInitialLighting(final long chunkPos) {
+        ((InitialLightingAccess) this.lightStorage).prepareInitialLighting(chunkPos);
+    }
+
+    @Override
+    public void cancelInitialLighting(final long chunkPos) {
+        ((InitialLightingAccess) this.lightStorage).cancelInitialLighting(chunkPos);
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLevelPropagator.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLevelPropagator.java
@@ -3,17 +3,19 @@ package me.jellysquid.mods.phosphor.mixin.chunk.light;
 import it.unimi.dsi.fastutil.longs.Long2ByteMap;
 import me.jellysquid.mods.phosphor.common.chunk.level.LevelPropagatorExtended;
 import me.jellysquid.mods.phosphor.common.chunk.level.LevelUpdateListener;
+import me.jellysquid.mods.phosphor.common.chunk.light.LevelPropagatorAccess;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.chunk.light.LevelPropagator;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LevelPropagator.class)
-public abstract class MixinLevelPropagator implements LevelPropagatorExtended, LevelUpdateListener {
+public abstract class MixinLevelPropagator implements LevelPropagatorExtended, LevelUpdateListener, LevelPropagatorAccess {
     @Shadow
     @Final
     private Long2ByteMap pendingUpdates;
@@ -30,6 +32,10 @@ public abstract class MixinLevelPropagator implements LevelPropagatorExtended, L
 
     @Shadow
     protected abstract void updateLevel(long sourceId, long id, int level, int currentLevel, int pendingLevel, boolean decrease);
+
+    @Override
+    @Invoker("propagateLevel")
+    public abstract void invokePropagateLevel(long sourceId, long targetId, int level, boolean decrease);
 
     // [VanillaCopy] LevelPropagator#propagateLevel(long, long, int, boolean)
     @Override

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
@@ -2,6 +2,7 @@ package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
 import it.unimi.dsi.fastutil.longs.*;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightInitializer;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightProviderUpdateTracker;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightStorageAccess;
@@ -10,6 +11,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.LightType;
+import net.minecraft.world.SectionDistanceLevelPropagator;
 import net.minecraft.world.chunk.ChunkNibbleArray;
 import net.minecraft.world.chunk.ChunkProvider;
 import net.minecraft.world.chunk.ChunkToNibbleArrayMap;
@@ -25,7 +27,11 @@ import java.util.concurrent.locks.StampedLock;
 
 @SuppressWarnings("OverwriteModifiers")
 @Mixin(LightStorage.class)
-public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> implements SharedLightStorageAccess<M>, LightStorageAccess {
+public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> extends SectionDistanceLevelPropagator implements SharedLightStorageAccess<M>, LightStorageAccess, InitialLightingAccess {
+    protected MixinLightStorage() {
+        super(0, 0, 0);
+    }
+
     @Shadow
     @Final
     protected M storage;
@@ -118,6 +124,11 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> impl
     @Override
     @Invoker("getLightSection")
     public abstract ChunkNibbleArray callGetLightSection(final long sectionPos, final boolean cached);
+
+    @Shadow
+    protected int getInitialLevel(long id) {
+        return 0;
+    }
 
     private final StampedLock uncachedLightArraysLock = new StampedLock();
 
@@ -447,5 +458,13 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> impl
     @Override
     public int getLightWithoutLightmap(final long blockPos) {
         return 0;
+    }
+
+    @Override
+    public void prepareInitialLighting(long chunkPos) {
+    }
+
+    @Override
+    public void cancelInitialLighting(long chunkPos) {
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightStorage.java
@@ -1,8 +1,13 @@
 package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
-import it.unimi.dsi.fastutil.longs.*;
+import it.unimi.dsi.fastutil.longs.Long2IntMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
-import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightInitializer;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightProviderUpdateTracker;
 import me.jellysquid.mods.phosphor.common.chunk.light.LightStorageAccess;
@@ -17,17 +22,25 @@ import net.minecraft.world.chunk.ChunkProvider;
 import net.minecraft.world.chunk.ChunkToNibbleArrayMap;
 import net.minecraft.world.chunk.light.ChunkLightProvider;
 import net.minecraft.world.chunk.light.LightStorage;
-import org.spongepowered.asm.mixin.*;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.concurrent.locks.StampedLock;
 
 @SuppressWarnings("OverwriteModifiers")
 @Mixin(LightStorage.class)
-public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> extends SectionDistanceLevelPropagator implements SharedLightStorageAccess<M>, LightStorageAccess, InitialLightingAccess {
+public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> extends SectionDistanceLevelPropagator implements SharedLightStorageAccess<M>, LightStorageAccess {
     protected MixinLightStorage() {
         super(0, 0, 0);
     }
@@ -90,14 +103,7 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
     protected abstract boolean hasLightUpdates();
 
     @Shadow
-    @Final
-    private LongSet columnsToRetain;
-
-    @Shadow
     protected abstract void onUnloadSection(long l);
-
-    @Shadow
-    public abstract boolean hasSection(long sectionPos);
 
     @Shadow
     @Final
@@ -177,6 +183,12 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
 
         long chunkPos = ChunkSectionPos.asLong(x >> 4, y >> 4, z >> 4);
 
+        final ChunkNibbleArray lightmap = this.getOrAddLightmap(chunkPos);
+        final int oldVal = lightmap.get(x & 15, y & 15, z & 15);
+
+        this.beforeLightChange(blockPos, oldVal, value, lightmap);
+        this.changeLightmapComplexity(chunkPos, this.getLightmapComplexityChange(blockPos, oldVal, value, lightmap));
+
         if (this.dirtySections.add(chunkPos)) {
             this.storage.replaceWithCopy(chunkPos);
         }
@@ -194,52 +206,30 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
     }
 
     /**
-     * Combines the contains/remove call to the queued removals set into a single remove call. See {@link MixinLightStorage#set(long, int)}
-     * for additional information.
-     *
-     * @reason Use faster implementation
-     * @author JellySquid
+     * @author PhiPro
+     * @reason Move large parts of the logic to other methods
      */
     @Overwrite
     public void setLevel(long id, int level) {
-        int prevLevel = this.getLevel(id);
+        int oldLevel = this.getLevel(id);
 
-        if (prevLevel != 0 && level == 0) {
+        if (oldLevel != 0 && level == 0) {
             this.readySections.add(id);
             this.markedReadySections.remove(id);
         }
 
-        if (prevLevel == 0 && level != 0) {
+        if (oldLevel == 0 && level != 0) {
             this.readySections.remove(id);
             this.markedNotReadySections.remove(id);
         }
 
-        if (prevLevel >= 2 && level != 2) {
-            if (!this.sectionsToRemove.remove(id)) {
-                this.storage.put(id, this.createSection(id));
-
-                this.dirtySections.add(id);
-                this.onLoadSection(id);
-
-                int x = BlockPos.unpackLongX(id);
-                int y = BlockPos.unpackLongY(id);
-                int z = BlockPos.unpackLongZ(id);
-
-                for (int z2 = (z - 1) >> 4; z2 <= (z + 1) >> 4; ++z2) {
-                    for (int x2 = (x - 1) >> 4; x2 <= (x + 1) >> 4; ++x2) {
-                        for (int y2 = (y - 1) >> 4; y2 <= (y + 1) >> 4; ++y2) {
-                            this.notifySections.add(ChunkSectionPos.asLong(x2, y2, z2));
-                        }
-                    }
-                }
-            }
+        if (oldLevel >= 2 && level < 2) {
+            this.nonOptimizableSections.add(id);
         }
 
-        if (prevLevel != 2 && level >= 2) {
-            this.sectionsToRemove.add(id);
+        if (oldLevel < 2 && level >= 2) {
+            this.nonOptimizableSections.remove(id);
         }
-
-        this.hasLightUpdates = !this.sectionsToRemove.isEmpty();
     }
 
     /**
@@ -255,81 +245,25 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
         }
     }
 
-    private final LongSet propagating = new LongOpenHashSet();
-
     /**
-     * @reason Avoid integer boxing, reduce map lookups and iteration as much as possible
-     * @author JellySquid
+     * @author PhiPro
+     * @reason Re-implement completely
      */
     @Overwrite
     public void updateLight(ChunkLightProvider<M, ?> chunkLightProvider, boolean doSkylight, boolean skipEdgeLightPropagation) {
-        if (!this.hasLightUpdates() && this.queuedSections.isEmpty()) {
+        if (!this.hasLightUpdates()) {
             return;
         }
 
-        LongSet propagating = this.propagating;
-        propagating.clear();
+        this.initializeChunks();
+        this.removeChunks(chunkLightProvider);
+        this.removeTrivialLightmaps(chunkLightProvider);
+        this.addQueuedLightmaps(chunkLightProvider);
 
-        LongIterator it = this.sectionsToRemove.iterator();
-
-        while (it.hasNext()) {
-            long pos = it.nextLong();
-
-            this.removeSection(chunkLightProvider, pos);
-
-            ChunkNibbleArray pending = this.queuedSections.remove(pos);
-            ChunkNibbleArray existing = this.storage.removeChunk(pos);
-
-            if (this.columnsToRetain.contains(ChunkSectionPos.withZeroY(pos))) {
-                if (pending != null) {
-                    this.queuedSections.put(pos, pending);
-                } else if (existing != null) {
-                    this.queuedSections.put(pos, existing);
-                }
-            }
-        }
-
-        this.storage.clearCache();
-        it = this.sectionsToRemove.iterator();
-
-        while (it.hasNext()) {
-            this.onUnloadSection(it.nextLong());
-        }
-
-        this.sectionsToRemove.clear();
-        this.hasLightUpdates = false;
-
-        ObjectIterator<Long2ObjectMap.Entry<ChunkNibbleArray>> addQueue = Long2ObjectMaps.fastIterator(this.queuedSections);
-
-        while (addQueue.hasNext()) {
-            Long2ObjectMap.Entry<ChunkNibbleArray> entry = addQueue.next();
-            long pos = entry.getLongKey();
-
-            if (this.hasSection(pos)) {
-                ChunkNibbleArray array = entry.getValue();
-
-                if (this.storage.get(pos) != array) {
-                    this.removeSection(chunkLightProvider, pos);
-
-                    this.storage.put(pos, array);
-                    this.dirtySections.add(pos);
-                }
-
-                // If edge light propagation will occur, we need to add the set of removed items to an intermediary set
-                // so the propagation code will not update touching faces of these sections
-                if (!skipEdgeLightPropagation) {
-                    propagating.add(pos);
-                }
-
-                // Early remove the entries from the queue so we don't have to later iterate and check hasLight again
-                addQueue.remove();
-            }
-        }
-
-        this.storage.clearCache();
+        final LongIterator it;
 
         if (!skipEdgeLightPropagation) {
-            it = propagating.iterator();
+            it = this.queuedSections.keySet().iterator();
         } else {
             it = this.queuedEdgeSections.iterator();
         }
@@ -339,9 +273,12 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
         }
 
         this.queuedEdgeSections.clear();
+        this.queuedSections.clear();
 
         // Vanilla would normally iterate back over the map of light arrays to remove those we worked on, but
         // that is unneeded now because we removed them earlier.
+
+        this.hasLightUpdates = false;
     }
 
     /**
@@ -359,7 +296,7 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
                 long adjPos = ChunkSectionPos.offset(pos, dir);
 
                 // Avoid updating initializing chunks unnecessarily
-                if (propagating.contains(adjPos)) {
+                if (this.queuedSections.containsKey(adjPos)) {
                     continue;
                 }
 
@@ -460,11 +397,396 @@ public abstract class MixinLightStorage<M extends ChunkToNibbleArrayMap<M>> exte
         return 0;
     }
 
-    @Override
-    public void prepareInitialLighting(long chunkPos) {
+    @Unique
+    protected void beforeChunkEnabled(final long chunkPos) {
     }
 
+    @Unique
+    protected void afterChunkDisabled(final long chunkPos) {
+    }
+
+    @Unique
+    private final LongSet enabledChunks = new LongOpenHashSet();
+    @Unique
+    protected final Long2IntMap lightmapComplexities = setDefaultReturnValue(new Long2IntOpenHashMap(), -1);
+
+    @Unique
+    private final LongSet markedEnabledChunks = new LongOpenHashSet();
+    @Unique
+    private final LongSet markedDisabledChunks = new LongOpenHashSet();
+    @Unique
+    private final LongSet trivialLightmaps = new LongOpenHashSet();
+
+    // This is put here since the relevant methods to overwrite are located in LightStorage
+    @Unique
+    protected LongSet nonOptimizableSections = new LongOpenHashSet();
+
+    @Unique
+    private static Long2IntMap setDefaultReturnValue(final Long2IntMap map, final int rv) {
+        map.defaultReturnValue(rv);
+        return map;
+    }
+
+    @Unique
+    protected ChunkNibbleArray getOrAddLightmap(final long sectionPos) {
+        ChunkNibbleArray lightmap = this.getLightSection(sectionPos, true);
+
+        if (lightmap != null) {
+            return lightmap;
+        }
+
+        lightmap = this.createSection(sectionPos);
+
+        this.storage.put(sectionPos, lightmap);
+        this.storage.clearCache();
+        this.dirtySections.add(sectionPos);
+
+        this.onLoadSection(sectionPos);
+        this.setLightmapComplexity(sectionPos, 0);
+
+        return lightmap;
+    }
+
+    @Unique
+    protected void setLightmapComplexity(final long sectionPos, final int complexity) {
+        int oldComplexity = this.lightmapComplexities.put(sectionPos, complexity);
+
+        if (oldComplexity == 0) {
+            this.trivialLightmaps.remove(sectionPos);
+            this.checkForLightUpdates();
+        }
+
+        if (complexity == 0) {
+            this.trivialLightmaps.add(sectionPos);
+            this.checkForLightUpdates();
+        }
+    }
+
+    @Unique
+    private void checkForLightUpdates() {
+        this.hasLightUpdates = !this.markedEnabledChunks.isEmpty() || !this.markedDisabledChunks.isEmpty() || !this.trivialLightmaps.isEmpty() || !this.queuedSections.isEmpty();
+    }
+
+    @Unique
+    protected void changeLightmapComplexity(final long sectionPos, final int amount) {
+        int complexity = this.lightmapComplexities.get(sectionPos);
+
+        if (complexity == 0) {
+            this.trivialLightmaps.remove(sectionPos);
+            this.checkForLightUpdates();
+        }
+
+        complexity += amount;
+        this.lightmapComplexities.put(sectionPos, complexity);
+
+        if (complexity == 0) {
+            this.trivialLightmaps.add(sectionPos);
+            this.checkForLightUpdates();
+        }
+    }
+
+    @Unique
+    protected boolean hasLightmap(final long sectionPos) {
+        return this.getLightSection(sectionPos, true) != null;
+    }
+
+    /**
+     * Set up lightmaps and adjust complexities as needed for the given light change.
+     * Actions are only required for other affected positions, not for the given <code>blockPos</code> directly.
+     */
+    @Unique
+    protected void beforeLightChange(final long blockPos, final int oldVal, final int newVal, final ChunkNibbleArray lightmap) {
+    }
+
+    @Unique
+    protected int getLightmapComplexityChange(final long blockPos, final int oldVal, final int newVal, final ChunkNibbleArray lightmap) {
+        return 0;
+    }
+
+    /**
+     * Set up lightmaps and adjust complexities as needed for the given lightmap change.
+     * Actions are only required for other affected sections, not for the given <code>sectionPos</code> directly.
+     */
+    @Unique
+    protected void beforeLightmapChange(final long sectionPos, final ChunkNibbleArray oldLightmap, final ChunkNibbleArray newLightmap) {
+    }
+
+    @Unique
+    protected int getInitialLightmapComplexity(final long sectionPos, final ChunkNibbleArray lightmap) {
+        return 0;
+    }
+
+    /**
+     * Determines whether light updates should be propagated into the given section.
+     * @author PhiPro
+     * @reason Method completely changed. Allow child mixins to properly extend this.
+     */
+    @Overwrite
+    public boolean hasSection(final long sectionPos) {
+        return this.enabledChunks.contains(ChunkSectionPos.withZeroY(sectionPos));
+    }
+
+    @Shadow
+    protected abstract void setColumnEnabled(long columnPos, boolean enabled);
+
     @Override
-    public void cancelInitialLighting(long chunkPos) {
+    @Invoker("setColumnEnabled")
+    public abstract void invokeSetColumnEnabled(final long chunkPos, final boolean enabled);
+
+    @Override
+    public void setLightUpdatesEnabled(final long chunkPos, final boolean enabled) {
+        if (enabled) {
+            if (this.markedDisabledChunks.remove(chunkPos) || this.enabledChunks.contains(chunkPos)) {
+                return;
+            }
+
+            this.markedEnabledChunks.add(chunkPos);
+            this.checkForLightUpdates();
+        } else {
+            if (this.markedEnabledChunks.remove(chunkPos) || !this.enabledChunks.contains(chunkPos)) {
+                for (int i = -1; i < 17; ++i) {
+                    final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos));
+
+                    if (this.storage.removeChunk(sectionPos) != null) {
+                        this.dirtySections.add(sectionPos);
+                    }
+                }
+
+                this.setColumnEnabled(chunkPos, false);
+            } else {
+                this.markedDisabledChunks.add(chunkPos);
+                this.checkForLightUpdates();
+            }
+        }
+    }
+
+    @Unique
+    private void initializeChunks() {
+        this.storage.clearCache();
+
+        for (final LongIterator it = this.markedEnabledChunks.iterator(); it.hasNext(); ) {
+            final long chunkPos = it.nextLong();
+
+            this.beforeChunkEnabled(chunkPos);
+
+            // First need to register all lightmaps via onLoadSection() as this data is needed for calculating the initial complexity
+
+            for (int i = -1; i < 17; ++i) {
+                final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos));
+
+                if (this.hasLightmap(sectionPos)) {
+                    this.onLoadSection(sectionPos);
+                }
+            }
+
+            // Now the initial complexities can be computed
+
+            for (int i = -1; i < 17; ++i) {
+                final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos));
+
+                if (this.hasLightmap(sectionPos)) {
+                    this.setLightmapComplexity(sectionPos, this.getInitialLightmapComplexity(sectionPos, this.getLightSection(sectionPos, true)));
+                }
+            }
+
+            this.enabledChunks.add(chunkPos);
+        }
+
+        this.markedEnabledChunks.clear();
+    }
+
+    @Unique
+    private void removeChunks(final ChunkLightProvider<?, ?> lightProvider) {
+        for (final LongIterator it = this.markedDisabledChunks.iterator(); it.hasNext(); ) {
+            final long chunkPos = it.nextLong();
+
+            // First need to remove all pending light updates before changing any light value
+
+            for (int i = -1; i < 17; ++i) {
+                final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos));
+
+                if (this.hasSection(sectionPos)) {
+                    this.removeSection(lightProvider, sectionPos);
+                }
+            }
+
+            // Now the chunk can be disabled
+
+            this.enabledChunks.remove(chunkPos);
+
+            // Now lightmaps can be removed
+
+            int sections = 0;
+
+            for (int i = -1; i < 17; ++i) {
+                final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos));
+
+                this.queuedSections.remove(sectionPos);
+
+                if (this.removeLightmap(sectionPos)) {
+                    sections |= 1 << (i + 1);
+                }
+            }
+
+            // Calling onUnloadSection() after removing all the lightmaps is slightly more efficient
+
+            this.storage.clearCache();
+
+            for (int i = -1; i < 17; ++i) {
+                if ((sections & (1 << (i + 1))) != 0) {
+                    this.onUnloadSection(ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), i, ChunkSectionPos.unpackZ(chunkPos)));
+                }
+            }
+
+            this.setColumnEnabled(chunkPos, false);
+            this.afterChunkDisabled(chunkPos);
+        }
+
+        this.markedDisabledChunks.clear();
+    }
+
+    /**
+     * Removes the lightmap associated to the provided <code>sectionPos</code>, but does not call {@link #onUnloadSection(long)} or {@link ChunkToNibbleArrayMap#clearCache()}
+     * @return Whether a lightmap was removed
+     */
+    @Unique
+    protected boolean removeLightmap(final long sectionPos) {
+        if (this.storage.removeChunk(sectionPos) == null) {
+            return false;
+        }
+
+        this.lightmapComplexities.remove(sectionPos);
+        this.trivialLightmaps.remove(sectionPos);
+        this.dirtySections.add(sectionPos);
+
+        return true;
+    }
+
+    @Unique
+    private void removeTrivialLightmaps(final ChunkLightProvider<?, ?> lightProvider) {
+        for (final LongIterator it = this.trivialLightmaps.iterator(); it.hasNext(); ) {
+            final long sectionPos = it.nextLong();
+
+            this.storage.removeChunk(sectionPos);
+            this.lightmapComplexities.remove(sectionPos);
+            this.dirtySections.add(sectionPos);
+        }
+
+        this.storage.clearCache();
+
+        // Calling onUnloadSection() after removing all the lightmaps is slightly more efficient
+
+        for (final LongIterator it = this.trivialLightmaps.iterator(); it.hasNext(); ) {
+            this.onUnloadSection(it.nextLong());
+        }
+
+        // Remove pending light updates for sections that no longer support light propagations
+
+        for (final LongIterator it = this.trivialLightmaps.iterator(); it.hasNext(); ) {
+            final long sectionPos = it.nextLong();
+
+            if (!this.hasSection(sectionPos)) {
+                this.removeSection(lightProvider, sectionPos);
+            }
+        }
+
+        this.trivialLightmaps.clear();
+    }
+
+    @Unique
+    private void addQueuedLightmaps(final ChunkLightProvider<?, ?> lightProvider) {
+        for (final ObjectIterator<Long2ObjectMap.Entry<ChunkNibbleArray>> it = Long2ObjectMaps.fastIterator(this.queuedSections); it.hasNext(); ) {
+            final Long2ObjectMap.Entry<ChunkNibbleArray> entry = it.next();
+
+            final long sectionPos = entry.getLongKey();
+            final ChunkNibbleArray lightmap = entry.getValue();
+
+            final ChunkNibbleArray oldLightmap = this.getLightSection(sectionPos, true);
+
+            if (lightmap != oldLightmap) {
+                this.removeSection(lightProvider, sectionPos);
+
+                this.beforeLightmapChange(sectionPos, oldLightmap, lightmap);
+
+                this.storage.put(sectionPos, lightmap);
+                this.storage.clearCache();
+                this.dirtySections.add(sectionPos);
+
+                if (oldLightmap == null) {
+                    this.onLoadSection(sectionPos);
+                }
+
+                this.setLightmapComplexity(sectionPos, this.getInitialLightmapComplexity(sectionPos, lightmap));
+            }
+        }
+    }
+
+    /**
+     * @author PhiPro
+     * @reason Add lightmaps for disabled chunks directly to the world
+     */
+    @Overwrite
+    public void enqueueSectionData(final long sectionPos, final ChunkNibbleArray array, final boolean bl) {
+        final boolean chunkEnabled = this.enabledChunks.contains(ChunkSectionPos.withZeroY(sectionPos));
+
+        if (array != null) {
+            if (chunkEnabled) {
+                this.queuedSections.put(sectionPos, array);
+            } else {
+                this.storage.put(sectionPos, array);
+                this.dirtySections.add(sectionPos);
+            }
+
+            if (!bl) {
+                this.queuedEdgeSections.add(sectionPos);
+            }
+        } else {
+            if (chunkEnabled) {
+                this.queuedSections.remove(sectionPos);
+            } else {
+                this.storage.removeChunk(sectionPos);
+                this.dirtySections.add(sectionPos);
+            }
+        }
+    }
+
+    // Queued lightmaps are only added to the world via updateLightmaps()
+    @Redirect(
+        method = "createSection(J)Lnet/minecraft/world/chunk/ChunkNibbleArray;",
+        slice = @Slice(
+            from = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/world/chunk/light/LightStorage;queuedSections:Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;",
+                opcode = Opcodes.GETFIELD
+            )
+        ),
+        at = @At(
+            value = "INVOKE",
+            target = "Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;get(J)Ljava/lang/Object;",
+            ordinal = 0,
+            remap = false
+        )
+    )
+    private Object cancelLightmapLookupFromQueue(final Long2ObjectMap<ChunkNibbleArray> lightmapArray, final long pos) {
+        return null;
+    }
+
+    @Redirect(
+        method = "getLevel(J)I",
+        slice = @Slice(
+            from = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/world/chunk/light/LightStorage;storage:Lnet/minecraft/world/chunk/ChunkToNibbleArrayMap;",
+                opcode = Opcodes.GETFIELD
+            )
+        ),
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/chunk/ChunkToNibbleArrayMap;containsKey(J)Z",
+            ordinal = 0
+        )
+    )
+    private boolean isNonOptimizable(final ChunkToNibbleArrayMap<?> lightmapArray, final long sectionPos) {
+        return this.nonOptimizableSections.contains(sectionPos);
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightingProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightingProvider.java
@@ -1,0 +1,45 @@
+package me.jellysquid.mods.phosphor.mixin.chunk.light;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
+import net.minecraft.world.chunk.light.ChunkLightProvider;
+import net.minecraft.world.chunk.light.LightingProvider;
+
+@Mixin(LightingProvider.class)
+public abstract class MixinLightingProvider implements InitialLightingAccess
+{
+    @Shadow
+    @Final
+    private ChunkLightProvider<?, ?> blockLightProvider;
+
+    @Shadow
+    @Final
+    private ChunkLightProvider<?, ?> skyLightProvider;
+
+    @Override
+    public void prepareInitialLighting(final long chunkPos)
+    {
+        if (this.blockLightProvider != null) {
+            ((InitialLightingAccess) this.blockLightProvider).prepareInitialLighting(chunkPos);
+        }
+
+        if (this.skyLightProvider != null) {
+            ((InitialLightingAccess) this.skyLightProvider).prepareInitialLighting(chunkPos);
+        }
+    }
+
+    @Override
+    public void cancelInitialLighting(final long chunkPos)
+    {
+        if (this.blockLightProvider != null) {
+            ((InitialLightingAccess) this.blockLightProvider).cancelInitialLighting(chunkPos);
+        }
+
+        if (this.skyLightProvider != null) {
+            ((InitialLightingAccess) this.skyLightProvider).cancelInitialLighting(chunkPos);
+        }
+    }
+}
+

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightingProvider.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinLightingProvider.java
@@ -1,11 +1,14 @@
 package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
+import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.chunk.light.ChunkLightProvider;
+import net.minecraft.world.chunk.light.LightingProvider;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import me.jellysquid.mods.phosphor.common.chunk.light.InitialLightingAccess;
-import net.minecraft.world.chunk.light.ChunkLightProvider;
-import net.minecraft.world.chunk.light.LightingProvider;
 
 @Mixin(LightingProvider.class)
 public abstract class MixinLightingProvider implements InitialLightingAccess
@@ -18,27 +21,41 @@ public abstract class MixinLightingProvider implements InitialLightingAccess
     @Final
     private ChunkLightProvider<?, ?> skyLightProvider;
 
+    @Shadow
+    public void setSectionStatus(ChunkSectionPos pos, boolean notReady) {
+    }
+
+    @Shadow
+    public void setColumnEnabled(ChunkPos pos, boolean lightEnabled) {
+    }
+
+    @Shadow
+    public void setRetainData(ChunkPos pos, boolean retainData) {
+    }
+
+    @Shadow
+    public void addLightSource(BlockPos pos, int level) {
+    }
+
     @Override
-    public void prepareInitialLighting(final long chunkPos)
-    {
+    public void enableSourceLight(final long chunkPos) {
         if (this.blockLightProvider != null) {
-            ((InitialLightingAccess) this.blockLightProvider).prepareInitialLighting(chunkPos);
+            ((InitialLightingAccess) this.blockLightProvider).enableSourceLight(chunkPos);
         }
 
         if (this.skyLightProvider != null) {
-            ((InitialLightingAccess) this.skyLightProvider).prepareInitialLighting(chunkPos);
+            ((InitialLightingAccess) this.skyLightProvider).enableSourceLight(chunkPos);
         }
     }
 
     @Override
-    public void cancelInitialLighting(final long chunkPos)
-    {
+    public void enableLightUpdates(final long chunkPos) {
         if (this.blockLightProvider != null) {
-            ((InitialLightingAccess) this.blockLightProvider).cancelInitialLighting(chunkPos);
+            ((InitialLightingAccess) this.blockLightProvider).enableLightUpdates(chunkPos);
         }
 
         if (this.skyLightProvider != null) {
-            ((InitialLightingAccess) this.skyLightProvider).cancelInitialLighting(chunkPos);
+            ((InitialLightingAccess) this.skyLightProvider).enableLightUpdates(chunkPos);
         }
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
@@ -11,7 +11,10 @@ import net.minecraft.world.chunk.light.SkyLightStorage;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.util.Arrays;
 import java.util.concurrent.locks.StampedLock;
 
 @Mixin(SkyLightStorage.class)
@@ -111,5 +114,22 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
         }
 
         return lightmap.get(ChunkSectionPos.getLocalCoord(BlockPos.unpackLongX(blockPos)), 0, ChunkSectionPos.getLocalCoord(BlockPos.unpackLongZ(blockPos)));
+    }
+
+    @Redirect(
+        method = "createSection(J)Lnet/minecraft/world/chunk/ChunkNibbleArray;",
+        at = @At(
+            value = "NEW",
+            target = "()Lnet/minecraft/world/chunk/ChunkNibbleArray;"
+        )
+    )
+    private ChunkNibbleArray initializeLightmap(final long pos) {
+        final ChunkNibbleArray ret = new ChunkNibbleArray();
+
+        if (this.isSectionEnabled(pos)) {
+            Arrays.fill(ret.asByteArray(), (byte) -1);
+        }
+
+        return ret;
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.phosphor.mixin.chunk.light;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
@@ -13,6 +14,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.chunk.ChunkNibbleArray;
 import net.minecraft.world.chunk.light.ChunkLightProvider;
 import net.minecraft.world.chunk.light.SkyLightStorage;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -21,6 +23,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Arrays;
@@ -108,18 +111,12 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
     protected abstract boolean isSectionEnabled(long sectionPos);
 
     @Override
-    public int getLightWithoutLightmap(final long blockPos)
-    {
-        long sectionPos = ChunkSectionPos.offset(ChunkSectionPos.fromBlockPos(blockPos), Direction.UP);
+    public int getLightWithoutLightmap(final long blockPos) {
+        final long sectionPos = ChunkSectionPos.fromBlockPos(blockPos);
+        final ChunkNibbleArray lightmap = this.getLightmapAbove(sectionPos);
 
-        if (this.isAtOrAboveTopmostSection(sectionPos)) {
+        if (lightmap == null) {
             return this.isSectionEnabled(sectionPos) ? 15 : 0;
-        }
-
-        ChunkNibbleArray lightmap;
-
-        while ((lightmap = this.getLightSection(sectionPos, true)) == null) {
-            sectionPos = ChunkSectionPos.offset(sectionPos, Direction.UP);
         }
 
         return lightmap.get(ChunkSectionPos.getLocalCoord(BlockPos.unpackLongX(blockPos)), 0, ChunkSectionPos.getLocalCoord(BlockPos.unpackLongZ(blockPos)));
@@ -167,13 +164,15 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
     private final LongSet preInitSkylightChunks = new LongOpenHashSet();
 
     @Override
-    public void prepareInitialLighting(final long chunkPos) {
-        this.preInitSkylightChunks.add(chunkPos);
-        this.updateLevel(Long.MAX_VALUE, ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), 16, ChunkSectionPos.unpackZ(chunkPos)), 1, true);
+    public void beforeChunkEnabled(final long chunkPos) {
+        if (!this.isSectionEnabled(chunkPos)) {
+            this.preInitSkylightChunks.add(chunkPos);
+            this.updateLevel(Long.MAX_VALUE, ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), 16, ChunkSectionPos.unpackZ(chunkPos)), 1, true);
+        }
     }
 
     @Override
-    public void cancelInitialLighting(final long chunkPos) {
+    public void afterChunkDisabled(final long chunkPos) {
         if (this.preInitSkylightChunks.remove(chunkPos)) {
             this.updateLevel(Long.MAX_VALUE, ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), 16, ChunkSectionPos.unpackZ(chunkPos)), 2, false);
         }
@@ -199,13 +198,15 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
 
     /**
      * @author PhiPro
-     * @reason Re-implement completely
+     * @reason Re-implement completely.
+     * This method now schedules initial lighting when enabling source light for a chunk that already has light updates enabled.
      */
+    @Override
     @Overwrite
     public void setColumnEnabled(final long chunkPos, final boolean enabled) {
         if (enabled) {
-            if (preInitSkylightChunks.contains(chunkPos)) {
-                initSkylightChunks.add(chunkPos);
+            if (this.preInitSkylightChunks.contains(chunkPos)) {
+                this.initSkylightChunks.add(chunkPos);
                 this.checkForUpdates();
             } else {
                 this.enabledColumns.add(chunkPos);
@@ -293,6 +294,18 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
 
         this.initSkylightChunks.clear();
 
+        for (final LongIterator it = this.markedOptimizableSections.iterator(); it.hasNext(); ) {
+            final long sectionPos = it.nextLong();
+
+            it.remove();
+
+            // Remove pending light updates for sections that no longer support light propagations
+
+            if (!this.hasSection(sectionPos)) {
+                this.removeSection(lightProvider, sectionPos);
+            }
+        }
+
         this.hasUpdates = false;
     }
 
@@ -301,8 +314,86 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
      * @return The section containing the topmost block or the section corresponding to {@link SkyLightStorage.Data#minSectionY} if none exists.
      */
     private int fillSkylightColumn(final ChunkLightProvider<SkyLightStorage.Data, ?> lightProvider, final long chunkPos) {
-        // TODO: Implement
-        return 0;
+        int minY = 16;
+        ChunkNibbleArray lightmapAbove = null;
+
+        // First need to remove all pending light updates before changing any light value
+
+        for (; this.isAboveMinHeight(minY); --minY) {
+            final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), minY, ChunkSectionPos.unpackZ(chunkPos));
+
+            if (this.readySections.contains(sectionPos)) {
+                break;
+            }
+
+            if (this.hasSection(sectionPos)) {
+                this.removeSection(lightProvider, sectionPos);
+            }
+
+            final ChunkNibbleArray lightmap = this.getLightSection(sectionPos, true);
+
+            if (lightmap != null) {
+                lightmapAbove = lightmap;
+            }
+        }
+
+        // Set up a lightmap and adjust the complexity for the section below
+
+        final long sectionPosBelow = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), minY, ChunkSectionPos.unpackZ(chunkPos));
+
+        if (this.hasSection(sectionPosBelow)) {
+            final ChunkNibbleArray lightmapBelow = this.getLightSection(sectionPosBelow, true);
+
+            if (lightmapBelow == null) {
+                int complexity = 15 * 16 * 16;
+
+                if (lightmapAbove != null) {
+                    for (int z = 0; z < 16; ++z) {
+                        for (int x = 0; x < 16; ++x) {
+                            complexity -= lightmapAbove.get(x, 0, z);
+                        }
+                    }
+                }
+
+                this.getOrAddLightmap(sectionPosBelow);
+                this.setLightmapComplexity(sectionPosBelow, complexity);
+            } else {
+                int amount = 0;
+
+                for (int z = 0; z < 16; ++z) {
+                    for (int x = 0; x < 16; ++x) {
+                        amount += getComplexityChange(lightmapBelow.get(x, 15, z), lightmapAbove == null ? 0 : lightmapAbove.get(x, 0, z), 15);
+                    }
+                }
+
+                this.changeLightmapComplexity(sectionPosBelow, amount);
+            }
+        }
+
+        // Now light values can be changed
+        // Delete lightmaps so the sections inherit direct skylight
+
+        int sections = 0;
+
+        for (int y = 16; y > minY; --y) {
+            final long sectionPos = ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), y, ChunkSectionPos.unpackZ(chunkPos));
+
+            if (this.removeLightmap(sectionPos)) {
+                sections |= 1 << (y + 1);
+            }
+        }
+
+        // Calling onUnloadSection() after removing all the lightmaps is slightly more efficient
+
+        this.storage.clearCache();
+
+        for (int y = 16; y > minY; --y) {
+            if ((sections & (1 << (y + 1))) != 0) {
+                this.onUnloadSection(ChunkSectionPos.asLong(ChunkSectionPos.unpackX(chunkPos), y, ChunkSectionPos.unpackZ(chunkPos)));
+            }
+        }
+
+        return minY;
     }
 
     @Shadow
@@ -314,6 +405,219 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
      */
     @Overwrite
     private void checkForUpdates() {
-        this.hasUpdates = !this.initSkylightChunks.isEmpty();
+        this.hasUpdates = !this.initSkylightChunks.isEmpty() || !this.markedOptimizableSections.isEmpty();
+    }
+
+    @Unique
+    private final LongSet markedOptimizableSections = new LongOpenHashSet();
+
+    @Override
+    public boolean hasSection(final long sectionPos) {
+        return super.hasSection(sectionPos) && (this.hasLightmap(sectionPos) || this.nonOptimizableSections.contains(sectionPos) || this.markedOptimizableSections.contains(sectionPos));
+    }
+
+    // Queued lightmaps are only added to the world via updateLightmaps()
+    @Redirect(
+        method = "createSection(J)Lnet/minecraft/world/chunk/ChunkNibbleArray;",
+        slice = @Slice(
+            from = @At(
+                value = "FIELD",
+                target = "Lnet/minecraft/world/chunk/light/SkyLightStorage;queuedSections:Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;",
+                opcode = Opcodes.GETFIELD
+            )
+        ),
+        at = @At(
+            value = "INVOKE",
+            target = "Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;get(J)Ljava/lang/Object;",
+            ordinal = 0,
+            remap = false
+        )
+    )
+    private Object cancelLightmapLookupFromQueue(final Long2ObjectMap<ChunkNibbleArray> lightmapArray, final long pos) {
+        return null;
+    }
+
+    @Unique
+    private static int getComplexityChange(final int val, final int oldNeighborVal, final int newNeighborVal) {
+        return Math.abs(newNeighborVal - val) - Math.abs(oldNeighborVal - val);
+    }
+
+    @Override
+    protected void beforeLightChange(final long blockPos, final int oldVal, final int newVal, final ChunkNibbleArray lightmap) {
+        if (ChunkSectionPos.getLocalCoord(BlockPos.unpackLongY(blockPos)) != 0) {
+            return;
+        }
+
+        final long sectionPosBelow = this.getSectionBelow(ChunkSectionPos.fromBlockPos(blockPos));
+
+        if (sectionPosBelow == Long.MAX_VALUE) {
+            return;
+        }
+
+        final ChunkNibbleArray lightmapBelow = this.getOrAddLightmap(sectionPosBelow);
+
+        final int x = ChunkSectionPos.getLocalCoord(BlockPos.unpackLongX(blockPos));
+        final int z = ChunkSectionPos.getLocalCoord(BlockPos.unpackLongZ(blockPos));
+
+        this.changeLightmapComplexity(sectionPosBelow, getComplexityChange(lightmapBelow.get(x, 15, z), oldVal, newVal));
+    }
+
+    @Shadow
+    protected abstract boolean isAboveMinHeight(final int sectionY);
+
+    /**
+     * Returns the first section below the provided <code>sectionPos</code> that {@link #hasSection(long) supports light propagations} or {@link Long#MAX_VALUE} if no such section exists.
+     */
+    @Unique
+    private long getSectionBelow(long sectionPos) {
+        for (int y = ChunkSectionPos.unpackY(sectionPos); this.isAboveMinHeight(y); --y) {
+            if (this.hasSection(sectionPos = ChunkSectionPos.offset(sectionPos, Direction.DOWN))) {
+                return sectionPos;
+            }
+        }
+
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    protected int getLightmapComplexityChange(final long blockPos, final int oldVal, final int newVal, final ChunkNibbleArray lightmap) {
+        final long sectionPos = ChunkSectionPos.fromBlockPos(blockPos);
+        final int x = ChunkSectionPos.getLocalCoord(BlockPos.unpackLongX(blockPos));
+        final int y = ChunkSectionPos.getLocalCoord(BlockPos.unpackLongY(blockPos));
+        final int z = ChunkSectionPos.getLocalCoord(BlockPos.unpackLongZ(blockPos));
+
+        final int valAbove;
+
+        if (y < 15) {
+            valAbove = lightmap.get(x, y + 1, z);
+        } else {
+            final ChunkNibbleArray lightmapAbove = this.getLightmapAbove(sectionPos);
+            valAbove = lightmapAbove == null ? this.getDirectSkylight(sectionPos) : lightmapAbove.get(x, 0, z);
+        }
+
+        int amount = getComplexityChange(valAbove, oldVal, newVal);
+
+        if (y > 0) {
+            amount += getComplexityChange(lightmap.get(x, y - 1, z), oldVal, newVal);
+        }
+
+        return amount;
+    }
+
+    /**
+     * Returns the first lightmap above the provided <code>sectionPos</code> or <code>null</code> if none exists.
+     */
+    @Unique
+    private ChunkNibbleArray getLightmapAbove(long sectionPos) {
+        sectionPos = ChunkSectionPos.offset(sectionPos, Direction.UP);
+
+        if (this.isAtOrAboveTopmostSection(sectionPos)) {
+            return null;
+        }
+
+        ChunkNibbleArray lightmap;
+
+        while ((lightmap = this.getLightSection(sectionPos, true)) == null) {
+            sectionPos = ChunkSectionPos.offset(sectionPos, Direction.UP);
+        }
+
+        return lightmap;
+    }
+
+    @Unique
+    private int getDirectSkylight(final long sectionPos) {
+        return this.isSectionEnabled(sectionPos) ? 15 : 0;
+    }
+
+    @Override
+    protected void beforeLightmapChange(final long sectionPos, final ChunkNibbleArray oldLightmap, final ChunkNibbleArray newLightmap) {
+        final long sectionPosBelow = this.getSectionBelow(sectionPos);
+
+        if (sectionPosBelow == Long.MAX_VALUE) {
+            return;
+        }
+
+        final ChunkNibbleArray lightmapBelow = this.getLightSection(sectionPosBelow, true);
+        final ChunkNibbleArray lightmapAbove = oldLightmap == null ? this.getLightmapAbove(sectionPos) : oldLightmap;
+
+        final int skyLight = this.getDirectSkylight(sectionPos);
+
+        if (lightmapBelow == null) {
+            int complexity = 0;
+
+            for (int z = 0; z < 16; ++z) {
+                for (int x = 0; x < 16; ++x) {
+                    complexity += Math.abs(newLightmap.get(x, 0, z) - (lightmapAbove == null ? skyLight : lightmapAbove.get(x, 0, z)));
+                }
+            }
+
+            if (complexity != 0) {
+                this.getOrAddLightmap(sectionPosBelow);
+                this.setLightmapComplexity(sectionPosBelow, complexity);
+            }
+        } else {
+            int amount = 0;
+
+            for (int z = 0; z < 16; ++z) {
+                for (int x = 0; x < 16; ++x) {
+                    amount += getComplexityChange(lightmapBelow.get(x, 15, z), lightmapAbove == null ? skyLight : lightmapAbove.get(x, 0, z), newLightmap.get(x, 0, z));
+                }
+            }
+
+            this.changeLightmapComplexity(sectionPosBelow, amount);
+        }
+    }
+
+    @Override
+    protected int getInitialLightmapComplexity(final long sectionPos, final ChunkNibbleArray lightmap) {
+        int complexity = 0;
+
+        for (int y = 0; y < 15; ++y) {
+            for (int z = 0; z < 16; ++z) {
+                for (int x = 0; x < 16; ++x) {
+                    complexity += Math.abs(lightmap.get(x, y + 1, z) - lightmap.get(x, y, z));
+                }
+            }
+        }
+
+        final ChunkNibbleArray lightmapAbove = this.getLightmapAbove(sectionPos);
+        final int skyLight = this.getDirectSkylight(sectionPos);
+
+        for (int z = 0; z < 16; ++z) {
+            for (int x = 0; x < 16; ++x) {
+                complexity += Math.abs((lightmapAbove == null ? skyLight : lightmapAbove.get(x, 0, z)) - lightmap.get(x, 15, z));
+            }
+        }
+
+        return complexity;
+    }
+
+    @Redirect(
+        method = "onUnloadSection(J)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/chunk/light/SkyLightStorage;hasSection(J)Z"
+        )
+    )
+    private boolean hasActualLightmap(final SkyLightStorage lightStorage, long sectionPos) {
+        return this.hasLightmap(sectionPos);
+    }
+
+    @Override
+    public void setLevel(final long id, final int level) {
+        final int oldLevel = this.getLevel(id);
+
+        if (oldLevel >= 2 && level < 2) {
+            ((SkyLightStorageDataAccess) (Object) this.storage).updateMinHeight(ChunkSectionPos.unpackY(id));
+            this.markedOptimizableSections.remove(id);
+            this.checkForUpdates();
+        }
+
+        if (oldLevel < 2 && level >= 2) {
+            this.markedOptimizableSections.add(id);
+            this.checkForUpdates();
+        }
+
+        super.setLevel(id, level);
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorage.java
@@ -12,7 +12,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.Arrays;
 import java.util.concurrent.locks.StampedLock;
@@ -131,5 +133,23 @@ public abstract class MixinSkyLightStorage extends MixinLightStorage<SkyLightSto
         }
 
         return ret;
+    }
+
+    @Inject(
+        method = "enqueueRemoveSection(J)V",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void disable_enqueueRemoveSection(final CallbackInfo ci) {
+        ci.cancel();
+    }
+
+    @Inject(
+        method = "enqueueAddSection(J)V",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void disable_enqueueAddSection(final CallbackInfo ci) {
+        ci.cancel();
     }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorageData.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/chunk/light/MixinSkyLightStorageData.java
@@ -84,4 +84,12 @@ public class MixinSkyLightStorageData extends ChunkToNibbleArrayMap<SkyLightStor
     public int getHeight(long pos) {
         return this.topArraySectionYQueue.getAsync(pos);
     }
+
+    @Override
+    public void updateMinHeight(final int y) {
+        if (this.minSectionY > y) {
+            this.minSectionY = y;
+            this.columnToTopSection.defaultReturnValue(this.minSectionY);
+        }
+    }
 }

--- a/src/main/java/me/jellysquid/mods/phosphor/mixin/client/world/MixinClientWorld.java
+++ b/src/main/java/me/jellysquid/mods/phosphor/mixin/client/world/MixinClientWorld.java
@@ -1,0 +1,22 @@
+package me.jellysquid.mods.phosphor.mixin.client.world;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.chunk.light.LightingProvider;
+
+@Mixin(ClientWorld.class)
+public abstract class MixinClientWorld
+{
+    @Redirect(
+        method = "unloadBlockEntities(Lnet/minecraft/world/chunk/WorldChunk;)V",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/chunk/light/LightingProvider;setColumnEnabled(Lnet/minecraft/util/math/ChunkPos;Z)V"
+        )
+    )
+    private void cancelDisableLightUpdates(final LightingProvider lightingProvider, final ChunkPos pos, final boolean enable) {
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,7 @@
   ],
   "accessWidener": "phosphor.accesswidener",
   "depends": {
-    "fabricloader": ">=0.8.0"
+    "fabricloader": ">=0.8.0",
+    "minecraft": ">=1.16.2"
   }
 }

--- a/src/main/resources/phosphor.mixins.json
+++ b/src/main/resources/phosphor.mixins.json
@@ -7,6 +7,7 @@
         "block.MixinShapeCache",
         "chunk.MixinChunkNibbleArray",
         "chunk.MixinWorldChunk",
+        "chunk.light.MixinLightingProvider",
         "chunk.light.MixinBlockLightStorageData",
         "chunk.light.MixinChunkBlockLightProvider",
         "chunk.light.MixinChunkLightProvider",

--- a/src/main/resources/phosphor.mixins.json
+++ b/src/main/resources/phosphor.mixins.json
@@ -25,6 +25,9 @@
         "chunk.MixinChunkStatus",
         "world.MixinChunkSerializer"
     ],
+    "client": [
+	    "client.world.MixinClientWorld"
+    ],
     "injectors": {
         "defaultRequire": 1
   }


### PR DESCRIPTION
The main motivation for this PR is to fix [MC-162253](https://bugs.mojang.com/browse/MC-162253). However, this issue is not directly focused by this PR, but instead comes out as a nice side effect of the following bug fixes.
The key step is to fix [MC-170010](https://bugs.mojang.com/browse/MC-170010) by directly initializing lightmaps upon creation with the previous light values at the respective positions. As a consequence, the skylight initialization, which was previously handled through the delayed lightmap initialization, needed to be rewritten as well. The code for this is copied from https://github.com/PhiPro95/mc-fixes/tree/mc-170010.
Unfortunately, due to the inevitable interference with [MC-196614](https://bugs.mojang.com/browse/MC-196614), this issue needs to be fixed first. As explained in the report, a naive fix would drastically increase memory consumed by empty lightmaps. Instead, the more general approach for improving lightmap handling by decoupling it from distance tracking, as described in [MC-196725](https://bugs.mojang.com/browse/MC-196725), is implemented. The code for this is copied from https://github.com/PhiPro95/mc-fixes/tree/mc-196725_vanilla-compat. Since the implementation requires proper lightmap initialization in order to simplify the complexity tracking of lightmaps, both issues depend on each other and are hence combined in this single PR.
Additionally, the implementation for [MC-196725](https://bugs.mojang.com/browse/MC-196725) used here contains additional code for maintaining Vanilla protocol and save compatibility, compared to the pure implementation https://github.com/PhiPro95/mc-fixes/tree/mc-196725. This adds back distance-based Vanilla lightmaps, which were removed by the pure implementation, but uses lightweight implementations for those maps, so they don't eat up any additional memory. Furthermore, data lost due to [MC-198987](https://bugs.mojang.com/browse/MC-198987) is recovered as good as possible, although full recovery is basically impossible as explained in the report.

As the change is rather large, I don't want to comment on the implementation here. All the relevant ideas are discussed in [MC-170010](https://bugs.mojang.com/browse/MC-170010) and [MC-196725](https://bugs.mojang.com/browse/MC-196725). Instead, I want to comment on some performance implications.

The main perfromance concern one might raise is that the new implementation for initial skylight required by the solution of [MC-170010](https://bugs.mojang.com/browse/MC-170010) loads an additional lightmap above the world. As explained in the report, some mechanism like that is necessary as soon as block changes can occur between `features` and `light` chunk status, which does not seem to be prohibited by any mechanism; and in fact `ProtoChunk` contains code for handling exactly this situation. This causes issues with Vanilla's approach of treating everything above the topmost block as opaque, as soon as the topmost block can change over time before initial lighting. In the report I discuss various approaches for mitigating this issue, although the discussion is admittedly a rather unstructured monologue. The bottom line is that one needs to specify the lighting model very precisely and take actions to enforce the specification. The idea that one should not care about the region above the topmost block, as it will be completely filled with skylight upon initial lighting anyway, inevitably leads to issues once the topmost block can change before initial lighting. Re-enforcing a precise light model would not only require to pull in light whenever increasing the height of the topmost block, but also to push out darkness whenever decreasing it; or to counteract these issue with some even more complicated specification.
Hence I chose to use the very simple approach of loading an additional lightmap above the world, emulating the idea that there is a stone platform above the world which gets removed upon initial lighting. This approach simply works with the usual light propagation code and does not require any further actions. Unfortunately, this comes at the cost of being a bit slower than the current Vanilla code due to the additional light propagations. However, there are various approaches for improving performance:
* The height of this additional lightmap could be reduced to a single block, rather than the full 16 blocks
* The resulting light distribution only depends on the state of the 8 neighbor chunks (are they already lighted or not?). Hence the result could be cached and wouldn't need to be propagated at all.
* Most importantly, the approach greatly benefits from batching light updates together. The implementation already contains the optimization to skip propagations into chunks that get initially lighted in the same update cycle. Hence, batching together initial lighting of many chunks basically eliminates the overhead completely.
Due to various reasons, the Vanilla batching currently does not work well for inital lighting. During preparation of the spawning area, the main thread tries to tick the lighting engine rather aggressively and doesn't let it batch operations. And during normal game ticks, only up to 5 operations are batched in the current Vanilla code. Since the scheduling for initial lighting already consists of 2 operations (one in the `PRE_UPDATES` and one in the `POST_UPDATES` phase) this means that only up to 2 chunks are batched together, leaving good oppurtunities for improvement.

On the other hand, when trying to implement some more sophisticated approach that needs to re-enforce the precise lighting specification, I don't see any way for optimizing the required repair actions, mainly because there isn't really enough information available for doing anything better than pulling in and pushing out all light values whenever the topmost block changes.
So, in conclusion I would argue that using this additional lightmap above the world is not only optimal in terms of code complexity, but should also be able to compete quite well with more sophisticated approaches performance wise; mainly because there are plenty of possible optimizations whereas I don't see any way for improvement for more complicated approaches.

Let me also remark here, that things like `/fill 0 255 0 175 255 175` actually take much longer with this PR compared to Vanilla. This is because of the rather small update batch size of 5, whereas Vanilla unintentionally processes whole chunks simultaneously through the lightmap initialization code, rather than the actual light propagation logic. This however comes at the cost of freezing the server and client for several seconds, similar to [MC-162253](https://bugs.mojang.com/browse/MC-162253). Hence I would say that the longer total processing time with this PR is a fair compromise, given that it eliminates the lag spikes caused by Vanilla. Moreover, increasing the batch size can greatly reduce the processing time, up to being more or less instantaneous.

Finally, let me point out a few ways for further optimizing this implementation. As the changes are already quite large I opted for the simplest possible implementation and leave optimizations to future PRs.
* Whenever looking up light values for a section without lightmap, the lighting engine has to search for the next lightmap above, from which skylight values are inherited. Whenever changing a skylight value at the bottom of a section, the lighting engine has to search for the next section below which is not skylight-optimizable and create a lightmap for it to save the old light value, as otherwise the changed light value would be inherited, breaking propagation paths. These two kinds of lookups can be stored by some double-linked data structure, which should improve these lookup times by quite a bit,
* The lightmap complexities are tracked by some additional `Long2IntMap`. It might be more optimal to store these together with the actual lightmaps in some compound object. However, this should be profiled first.
* In order to implement the lightweight Vanilla lightmaps, I added some subclasses to `ChunkNibbleArray`. This might make some callsites polymorphic and annoy the JIT. Hence it might be more optimal to implement this by directly injecting into `ChunkNibbleArray` rather than subclassing it. However, this definitely reduces code readability, so again should be carefully profiled first.

Best,
PhiPro