### PR TITLE
Update Loom Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.4-SNAPSHOT'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Mods don't seem to build anymore on loom 0.5 and below, so I updated it to 0.6. I have only observed it on 0.5, but someone informed me that it should also be an issue on all lower versions.