### PR TITLE
This mod is not compatible with starlight

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
     "fabricloader": ">=0.8.0",
     "minecraft": ">=1.16.2"
   },
-  "conflicts": {
+  "breaks": {
     "starlight": "*"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,5 +27,8 @@
   "depends": {
     "fabricloader": ">=0.8.0",
     "minecraft": ">=1.16.2"
+  },
+  "conflicts": {
+    "starlight": "*"
   }
 }


### PR DESCRIPTION
I don't know why this wasn't done earlier. If you would like me to add more mods, either comment here or ping me on discord (`DragonEggBedrockBreaking#0034).

The two commits are there in case you just want to cherry-pick the first one (the difference is that the first one just annoys you in logs, whereas the second actually crashes the game, in case someone who doesn't know about this is reading this).

I don't see why you would want to do that, because when both mods (latest releases) are used, the game freezes on the world loading screen, but at least you have the option... For more info on this, you can see the [information put in logs](https://gist.github.com/DragonEggBedrockBreaking/5b787c08c2eca1f3461fd11aee5f63e1).