### PR TITLE
change: Update to Loom mappings 23w12a+build.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=23w12a
-yarn_mappings=23w12a+build.1
-loader_version=0.14.18
+minecraft_version=23w14a
+yarn_mappings=23w14a+build.6
+loader_version=0.14.19
 
 # Mod Properties
 mod_version=0.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/versions.html
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=23w12a
+yarn_mappings=23w12a+build.1
+loader_version=0.14.18
 
 # Mod Properties
 mod_version=0.8.1

--- a/src/main/java/net/caffeinemc/phosphor/mixin/chunk/MixinWorldChunk.java
+++ b/src/main/java/net/caffeinemc/phosphor/mixin/chunk/MixinWorldChunk.java
@@ -1,9 +1,9 @@
 package net.caffeinemc.phosphor.mixin.chunk;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.registry.Registry;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.world.HeightLimitView;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.Chunk;


### PR DESCRIPTION
This build currently works and runs fine, I will try to remember to update this when 1.20 releases fully (please ping me if my pull request has not been updated on release day).

I'm not expecting this to be merged, but I hope it is of convenience for anyone who would like to use phosphor on the latest snapshot.